### PR TITLE
Adds support for non-default SoftHSM versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@
 
 FROM alpine:3.8
 
-ENV SOFTHSM2_VERSION=2.5.0 \
+ARG SOFTHSM2_VERSION=2.5.0
+
+ENV SOFTHSM2_VERSION=${SOFTHSM2_VERSION} \
     SOFTHSM2_SOURCES=/tmp/softhsm2
 
 # install build dependencies

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Build and run the image
 
+### With the default version of [SoftHSM](https://github.com/opendnssec/SoftHSMv2/tags)
+
 1.  Build the image
 
         $ docker build --tag softhsm2:2.5.0 .
@@ -9,6 +11,17 @@
 2.  Run the image
 
         $ docker run -ti --rm softhsm2:2.5.0 sh -l
+
+### With a specific version of [SoftHSM](https://github.com/opendnssec/SoftHSMv2/tags)
+
+1.  Build the image
+
+        $ VERSION=2.6.1 && docker build --build-arg SOFTHSM2_VERSION=$VERSION --tag softhsm2:$VERSION .
+
+2.  Run the image
+
+        $ docker run -ti --rm softhsm2:2.6.1 sh -l
+
 
 ## Test it
 


### PR DESCRIPTION
This change adds support to the Dockerfile for building with alternative SoftHSM versions. The use of ARG and ENV settings exist to allow the version to be both defaulted or passed in while also making that value available as an environment variable in the built image.